### PR TITLE
Switch nginx to HTTPS with Let's Encrypt certs and use NGINX Agent to expose metrics

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,7 @@
 ---
 name: config-docs
 title: Configuration Docs
-version: main
+version: poc-nginx-agent
 start_page: ROOT:index.adoc
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
### Description
This pull request updates the configuration for nginx to use HTTPS with Let's Encrypt certificates instead of HTTP. Additionally, it uses the NGINX Agent to expose metrics to Prometheus and Grafana.

The updated configuration includes the installation and configuration of certbot to obtain and renew Let's Encrypt certificates automatically. The NGINX Agent is used to collect and expose metrics to Prometheus and Grafana. The configuration also includes the necessary changes to nginx to support HTTPS.

#91 
#104 

### Type of change
- New feature (non-breaking change which adds functionality)
